### PR TITLE
Add "Complete Your Story" progress checklist for profile owners

### DIFF
--- a/style.css
+++ b/style.css
@@ -5044,6 +5044,121 @@ a.marriage-timeline-name:hover {
    ========================================================================== */
 
 /* Profile Sections */
+/* Story completion progress checklist */
+.story-progress {
+	background: var(--color-white);
+	border: 2px solid var(--color-orange);
+	border-radius: 8px;
+	margin-bottom: 2rem;
+	padding: 1.25rem 1.5rem;
+}
+@media (prefers-color-scheme: dark) {
+	.story-progress {
+		background: var(--global-font-color, #111);
+	}
+}
+.story-progress-header {
+	align-items: baseline;
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 0.5rem;
+}
+.story-progress-title {
+	font-size: 1.1rem;
+	font-weight: 700;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+}
+.story-progress-count {
+	font-size: 0.9rem;
+	opacity: 0.75;
+}
+.story-progress-bar-wrap {
+	background: var(--color-gray-1, #e0e0e0);
+	border-radius: 4px;
+	height: 10px;
+	margin-bottom: 0.75rem;
+	overflow: hidden;
+	width: 100%;
+}
+.story-progress-bar {
+	background: var(--color-orange);
+	border-radius: 4px;
+	height: 100%;
+	min-width: 4px;
+	transition: width 0.4s ease;
+}
+.story-progress-message {
+	font-size: 0.95rem;
+	margin: 0 0 1rem;
+	opacity: 0.85;
+}
+.story-progress-checklist {
+	columns: 2;
+	gap: 0.25rem 1.5rem;
+	list-style: none;
+	margin: 0 0 1rem;
+	padding: 0;
+}
+@media only screen and (max-width: 600px) {
+	.story-progress-checklist {
+		columns: 1;
+	}
+}
+.story-progress-item {
+	align-items: center;
+	break-inside: avoid;
+	display: flex;
+	font-size: 0.9rem;
+	gap: 0.4rem;
+	padding: 0.2rem 0;
+}
+.story-progress-check {
+	border-radius: 50%;
+	border: 2px solid currentColor;
+	flex-shrink: 0;
+	height: 16px;
+	opacity: 0.35;
+	position: relative;
+	width: 16px;
+}
+.story-progress-item.is-done .story-progress-check {
+	background: var(--color-orange);
+	border-color: var(--color-orange);
+	opacity: 1;
+}
+.story-progress-item.is-done .story-progress-check::after {
+	border-bottom: 2px solid white;
+	border-right: 2px solid white;
+	content: '';
+	height: 8px;
+	left: 3px;
+	position: absolute;
+	top: 1px;
+	transform: rotate(45deg);
+	width: 5px;
+}
+.story-progress-item.is-done .story-progress-item-label {
+	opacity: 0.6;
+	text-decoration: line-through;
+}
+.story-progress-cta {
+	background: var(--color-orange);
+	border-radius: 100px;
+	color: white;
+	display: inline-block;
+	font-size: 0.95rem;
+	font-weight: 600;
+	padding: 0.4rem 1.25rem;
+	text-decoration: none;
+	transition: opacity 0.2s ease;
+}
+.story-progress-cta:hover {
+	color: white;
+	opacity: 0.85;
+	text-decoration: none;
+}
+
 .profile-section {
 	margin-bottom: 2rem;
 	padding-bottom: 1rem;

--- a/template-edit.php
+++ b/template-edit.php
@@ -36,7 +36,9 @@ get_header(); ?>
 	<?php endif; ?>
 
 	<div class="entry-content">
-		<?php 
+		<?php
+			set_query_var( 'userid', get_current_user_id() );
+			get_template_part( 'template-parts/content/content', 'user-progress' );
 			the_content();
 			acf_form(
 				array(

--- a/template-parts/content/content-user-progress.php
+++ b/template-parts/content/content-user-progress.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Template part for the "Complete Your Story" progress checklist.
+ * Shown only on a user's own profile and the edit page (logged-in only).
+ *
+ * Expects $userid to be available via set_query_var / load_template extraction.
+ */
+
+if ( ! $userid || ! is_user_logged_in() ) {
+	return;
+}
+
+// Gather completion state for each of the 10 items
+$completed = [];
+
+$completed['hi']       = (bool) get_field( 'hi', 'user_' . $userid );
+$completed['tagline']  = (bool) get_field( 'tagline', 'user_' . $userid );
+$completed['media']    = (bool) get_field( 'photo', 'user_' . $userid )
+                      || (bool) get_field( 'video', 'user_' . $userid );
+$completed['about_me'] = (bool) get_field( 'about_me', 'user_' . $userid );
+$completed['why_left'] = (bool) get_field( 'why_i_left', 'user_' . $userid );
+
+$question_rows = get_field( 'questions', 'user_' . $userid );
+$answered = 0;
+if ( is_array( $question_rows ) ) {
+	foreach ( $question_rows as $row ) {
+		if ( ! empty( $row['answer'] ) ) {
+			$answered++;
+		}
+	}
+}
+$completed['q1']      = $answered >= 1;
+$completed['q2']      = $answered >= 2;
+$completed['q3']      = $answered >= 3;
+$completed['spectrum'] = ! empty( get_field( 'mormon_spectrum', 'user_' . $userid ) );
+$completed['shelf']    = ! empty( get_field( 'my_shelf', 'user_' . $userid ) );
+
+$total = count( $completed );
+$done  = count( array_filter( $completed ) );
+$pct   = $total > 0 ? round( $done / $total * 100 ) : 0;
+
+if ( $pct === 100 ) {
+	$message = 'Your story is complete! Thank you for sharing.';
+} elseif ( $pct >= 80 ) {
+	$message = 'Almost there — just a few more details to add.';
+} elseif ( $pct >= 50 ) {
+	$message = 'Great progress! Keep going to help others find your story.';
+} elseif ( $pct >= 20 ) {
+	$message = 'Good start — fill in more to make your story shine.';
+} else {
+	$message = 'Help others connect with your experience — complete your story.';
+}
+
+$items = [
+	'hi'       => 'Introduction',
+	'tagline'  => 'Tagline',
+	'media'    => 'Photo or video',
+	'about_me' => 'About me',
+	'why_left' => 'Why I left',
+	'q1'       => 'Question answer (1 of 3)',
+	'q2'       => 'Question answer (2 of 3)',
+	'q3'       => 'Question answer (3 of 3)',
+	'spectrum' => 'Mormon Spectrum label',
+	'shelf'    => 'On my shelf label',
+];
+?>
+
+<aside class="story-progress" aria-label="Story completion progress">
+	<div class="story-progress-header">
+		<span class="story-progress-title">Complete Your Story</span>
+		<span class="story-progress-count"><?php echo esc_html( $done . ' / ' . $total ); ?></span>
+	</div>
+	<div class="story-progress-bar-wrap" role="progressbar" aria-valuenow="<?php echo esc_attr( $pct ); ?>" aria-valuemin="0" aria-valuemax="100" aria-label="<?php echo esc_attr( $pct . '% complete' ); ?>">
+		<div class="story-progress-bar" style="width:<?php echo esc_attr( $pct ); ?>%"></div>
+	</div>
+	<p class="story-progress-message"><?php echo esc_html( $message ); ?></p>
+	<ul class="story-progress-checklist">
+		<?php foreach ( $items as $key => $label ) : ?>
+		<li class="story-progress-item <?php echo $completed[ $key ] ? 'is-done' : 'is-todo'; ?>">
+			<span class="story-progress-check" aria-hidden="true"></span>
+			<span class="story-progress-item-label"><?php echo esc_html( $label ); ?></span>
+		</li>
+		<?php endforeach; ?>
+	</ul>
+	<?php if ( $pct < 100 ) : ?>
+	<a class="story-progress-cta" href="<?php echo esc_url( home_url( '/edit/' ) ); ?>">Edit your story</a>
+	<?php endif; ?>
+</aside>

--- a/template-parts/content/content-user.php
+++ b/template-parts/content/content-user.php
@@ -11,6 +11,13 @@ $curauth = (get_query_var('author_name')) ? get_user_by('slug', get_query_var('a
 <?php set_query_var( 'userid', $userid ); ?>
 <?php get_template_part( 'template-parts/content/content', 'user-header' ); ?>
 
+<?php
+// Show progress checklist only when viewing your own profile
+if ( is_user_logged_in() && (int) $userid === (int) get_current_user_id() ) {
+	get_template_part( 'template-parts/content/content', 'user-progress' );
+}
+?>
+
 <?php if ( get_field( 'about_me', 'user_' . $userid ) ) { ?>
 	<div class="profile-section" id="about-me">
 		<h3>About me</h3>


### PR DESCRIPTION
## Summary

Adds a "Complete Your Story" progress bar and checklist shown exclusively to the logged-in profile owner — both at the top of their own profile page and at the top of the edit page.

## What's included

**10-item checklist** tracking:
1. Introduction (hi field)
2. Tagline
3. Photo or video (counts as one item — either satisfies it)
4. About me
5. Why I left
6. Question answer 1 of 3
7. Question answer 2 of 3
8. Question answer 3 of 3
9. Mormon Spectrum label (any count)
10. On my shelf label (any count)

**Progress bar** fills proportionally; percentage-based encouragement message adapts to where the user is in their journey (5 tiers: <20%, <50%, <80%, <100%, complete).

**Visual treatment:**
- Completed items: filled orange checkmark + strikethrough label
- Remaining items: hollow circle + normal label
- Two-column layout on desktop, single column on mobile
- "Edit your story" CTA button hidden once 100% complete

## Files changed

| File | Change |
|------|--------|
| `template-parts/content/content-user-progress.php` | New template part — all checklist logic and markup |
| `template-parts/content/content-user.php` | Include progress part at top when `$userid === get_current_user_id()` |
| `template-edit.php` | Include progress part at top of edit form (page already requires login) |
| `style.css` | Progress bar, checklist, checkmark, and CTA button styles |

---
_Generated by [Claude Code](https://claude.ai/code/session_014xzm7YA6o7y6qz3dyqzqPp)_