### PR TITLE
fix(prep-release): fail fast when RELEASE_PAT secret is missing

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -49,6 +49,15 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check RELEASE_PAT is configured
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "${RELEASE_PAT}" ]; then
+            echo "::error::RELEASE_PAT secret is not set. Create a fine-grained PAT with Contents: write and Pull requests: write on this repo, then add it under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

- Adds an early guard step to `prep-release.yml` that checks `RELEASE_PAT` is set before doing any work
- Without this, the workflow would push the release branch successfully, then fail on `gh pr create` with a confusing "GH_TOKEN not set" error — leaving an orphaned branch that blocks re-running at the same version
- Now it exits at step 1 with a clear actionable error pointing to Settings → Secrets and variables → Actions

## Test plan

- [ ] Verify the workflow fails immediately with the RELEASE_PAT error message when the secret is not set
- [ ] Verify the workflow proceeds normally once RELEASE_PAT is added

---
_Generated by [Claude Code](https://claude.ai/code/session_011dsyQhQyh9yQuT64cVRFG1)_