### PR TITLE
chore(lint): replace phpcs:ignore suppressions with real fixes (#70)

### DIFF
--- a/blocks/saints-leadership/render.php
+++ b/blocks/saints-leadership/render.php
@@ -314,7 +314,7 @@ if ( $filter_mode === 'custom' ) {
 
 			// Combine: past presidents + current president
 			$all_presidents = $past_presidents;
-			if ( $current_president_id && ! in_array( $current_president_id, $all_presidents ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+			if ( $current_president_id && ! in_array( $current_president_id, $all_presidents, true ) ) {
 				$all_presidents[] = $current_president_id;
 			}
 

--- a/includes/contributor-posts-admin-page.php
+++ b/includes/contributor-posts-admin-page.php
@@ -184,7 +184,7 @@ class Wasmo_Contributor_Post_List_Table extends WP_List_Table {
 				return $item[ $column_name ];
 
 			default:
-				return print_r( $item, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				return wp_json_encode( $item );
 		}
 	}
 

--- a/includes/contributor-users-admin-page.php
+++ b/includes/contributor-users-admin-page.php
@@ -227,7 +227,7 @@ class Wasmo_Contributor_User_List_Table extends WP_List_Table {
 				return $item[ $column_name ];
 
 			default:
-				return print_r( $item, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				return wp_json_encode( $item );
 		}
 	}
 

--- a/includes/draft-posts-admin-page.php
+++ b/includes/draft-posts-admin-page.php
@@ -203,7 +203,7 @@ class Wasmo_Draft_Post_List_Table extends WP_List_Table {
 				return $item[ $column_name ];
 
 			default:
-				return print_r( $item, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				return wp_json_encode( $item );
 		}
 	}
 

--- a/includes/fs-verify.php
+++ b/includes/fs-verify.php
@@ -977,7 +977,7 @@ function wasmo_sideload_fs_portrait( $saint_id, $image_url, $force = false ) {
 
 	// Clean up temp file if still exists
 	if ( file_exists( $tmp ) ) {
-		@unlink( $tmp ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+		wp_delete_file( $tmp );
 	}
 
 	if ( is_wp_error( $attachment_id ) ) {

--- a/includes/functions-acf.php
+++ b/includes/functions-acf.php
@@ -268,7 +268,6 @@ add_action( 'acf/init', 'wasmo_register_acf_options_pages' );
  *
  * @param string $value The value.
  * @param string $post_id The post ID.
- * @param array  $field The field array.
  * @return string The default display name value.
  */
 function wasmo_get_default_display_name_value( $value, $post_id ) {
@@ -288,7 +287,6 @@ add_filter( 'acf/load_value/name=display_name', 'wasmo_get_default_display_name_
  *
  * @param string $value The value.
  * @param string $post_id The post ID.
- * @param array  $field The field array.
  * @return string The default profile id value.
  */
 function wasmo_get_default_profile_id_value( $value, $post_id ) {
@@ -404,8 +402,6 @@ add_action( 'acf/save_post', 'wasmo_update_spotlight', 10 );
 
 /**
  * Delete user
- *
- * @param int $user_id The user ID.
  */
 function wasmo_delete_user() {
 	// clear all directory transients

--- a/includes/functions-acf.php
+++ b/includes/functions-acf.php
@@ -271,7 +271,7 @@ add_action( 'acf/init', 'wasmo_register_acf_options_pages' );
  * @param array  $field The field array.
  * @return string The default display name value.
  */
-function wasmo_get_default_display_name_value( $value, $post_id, $field ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+function wasmo_get_default_display_name_value( $value, $post_id ) {
 	if ( $value === null || $value === '' ) {
 		$user_id          = intval( substr( $post_id, 5 ) );
 		$user_info        = get_userdata( $user_id );
@@ -291,7 +291,7 @@ add_filter( 'acf/load_value/name=display_name', 'wasmo_get_default_display_name_
  * @param array  $field The field array.
  * @return string The default profile id value.
  */
-function wasmo_get_default_profile_id_value( $value, $post_id, $field ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+function wasmo_get_default_profile_id_value( $value, $post_id ) {
 	if ( $value === null || $value === '' ) {
 		$user_id       = intval( substr( $post_id, 5 ) );
 		$user_info     = get_userdata( $user_id );
@@ -407,7 +407,7 @@ add_action( 'acf/save_post', 'wasmo_update_spotlight', 10 );
  *
  * @param int $user_id The user ID.
  */
-function wasmo_delete_user( $user_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+function wasmo_delete_user() {
 	// clear all directory transients
 	wasmo_delete_transients_with_prefix( 'wasmo_directory-' );
 }

--- a/includes/functions-admin.php
+++ b/includes/functions-admin.php
@@ -107,7 +107,7 @@ function wasmo_admin_column_styles() {
 	global $pagenow;
 
 	// Only on edit pages
-	if ( ! in_array( $pagenow, array( 'edit.php', 'users.php' ) ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+	if ( ! in_array( $pagenow, array( 'edit.php', 'users.php' ), true ) ) {
 		return;
 	}
 	?>
@@ -333,7 +333,7 @@ add_action( 'wp_before_admin_bar_render', 'wasmo_admin_bar_render' );
 function wasmo_posts_for_current_author( $query ) {
 	global $pagenow;
 
-	if ( 'edit.php' != $pagenow || ! $query->is_admin ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+	if ( 'edit.php' !== $pagenow || ! $query->is_admin ) {
 		return $query;
 	}
 
@@ -376,62 +376,62 @@ function wasmo_fix_post_counts( $views ) {
 			'post_status' => $type['status'],
 		);
 		$result = new WP_Query( $query );
-		if ( $type['status'] == null ) : // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
-			$class        = ( $wp_query->query_vars['post_status'] == null ) ? ' class="current"' : ''; // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		if ( $type['status'] === null ) :
+			$class        = ( $wp_query->query_vars['post_status'] === null ) ? ' class="current"' : '';
 			$views['all'] = sprintf(
 				'<a href="%s" ' . $class . '>All <span class="count">(%d)</span></a>',
 				admin_url( 'edit.php?post_type=post' ),
 				$result->found_posts
 			);
-		elseif ( $type['status'] == 'publish' ) : // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		elseif ( $type['status'] === 'publish' ) :
 			if ( $result->found_posts === 0 ) {
 				unset( $views['publish'] );
 			} else {
-				$class            = ( $wp_query->query_vars['post_status'] == 'publish' ) ? ' class="current"' : ''; // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+				$class            = ( $wp_query->query_vars['post_status'] === 'publish' ) ? ' class="current"' : '';
 				$views['publish'] = sprintf(
 					'<a href="%s" ' . $class . '>Published <span class="count">(%d)</span></a>',
 					admin_url( 'edit.php?post_status=publish&post_type=post' ),
 					$result->found_posts
 				);
 			}
-		elseif ( $type['status'] == 'draft' ) : // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		elseif ( $type['status'] === 'draft' ) :
 			if ( $result->found_posts === 0 ) {
 				unset( $views['draft'] );
 			} else {
-				$class          = ( $wp_query->query_vars['post_status'] == 'draft' ) ? ' class="current"' : ''; // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+				$class          = ( $wp_query->query_vars['post_status'] === 'draft' ) ? ' class="current"' : '';
 				$views['draft'] = sprintf(
 					'<a href="%s" ' . $class . '>Draft' . ( ( count( $result->posts ) > 1 ) ? 's' : '' ) . ' <span class="count">(%d)</span></a>',
 					admin_url( 'edit.php?post_status=draft&post_type=post' ),
 					$result->found_posts
 				);
 			}
-		elseif ( $type['status'] == 'future' ) : // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		elseif ( $type['status'] === 'future' ) :
 			if ( $result->found_posts === 0 ) {
 				unset( $views['future'] );
 			} else {
-				$class           = ( $wp_query->query_vars['post_status'] == 'future' ) ? ' class="future"' : ''; // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+				$class           = ( $wp_query->query_vars['post_status'] === 'future' ) ? ' class="future"' : '';
 				$views['future'] = sprintf(
 					'<a href="%s" ' . $class . '>Scheduled <span class="count">(%d)</span></a>',
 					admin_url( 'edit.php?post_status=future&post_type=post' ),
 					$result->found_posts
 				);
 			}
-		elseif ( $type['status'] == 'pending' ) : // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		elseif ( $type['status'] === 'pending' ) :
 			if ( $result->found_posts === 0 ) {
 				unset( $views['pending'] );
 			} else {
-				$class            = ( $wp_query->query_vars['post_status'] == 'pending' ) ? ' class="current"' : ''; // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+				$class            = ( $wp_query->query_vars['post_status'] === 'pending' ) ? ' class="current"' : '';
 				$views['pending'] = sprintf(
 					'<a href="%s" ' . $class . '>Pending <span class="count">(%d)</span></a>',
 					admin_url( 'edit.php?post_status=pending&post_type=post' ),
 					$result->found_posts
 				);
 			}
-		elseif ( $type['status'] == 'trash' ) : // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		elseif ( $type['status'] === 'trash' ) :
 			if ( $result->found_posts === 0 ) {
 				unset( $views['trash'] );
 			} else {
-				$class          = ( $wp_query->query_vars['post_status'] == 'trash' ) ? ' class="current"' : ''; // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+				$class          = ( $wp_query->query_vars['post_status'] === 'trash' ) ? ' class="current"' : '';
 				$views['trash'] = sprintf(
 					'<a href="%s" ' . $class . '>Trash <span class="count">(%d)</span></a>',
 					admin_url( 'edit.php?post_status=trash&post_type=post' ),

--- a/includes/functions-email.php
+++ b/includes/functions-email.php
@@ -273,7 +273,7 @@ add_action( 'transition_post_status', 'wasmo_pending_submission_notifications_se
 
 // https://github.com/wp-plugins/oa-social-login/blob/master/filters.txt
 // This function will be called after Social Login has added a new user
-function wasmo_oa_social_login_do_after_user_insert( $user_data, $identity ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+function wasmo_oa_social_login_do_after_user_insert( $user_data ) {
 	// These are the fields from the WordPress database
 	// print_r($user_data);
 	// This is the full social network profile of this user
@@ -287,7 +287,7 @@ function wasmo_oa_social_login_do_after_user_insert( $user_data, $identity ) { /
 // add_action ('oa_social_login_action_after_user_insert', 'wasmo_oa_social_login_do_after_user_insert', 10, 2);
 
 // This function will be called before Social Login logs the user in
-function wasmo_oa_social_login_do_before_user_login( $user_data, $identity, $new_registration ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+function wasmo_oa_social_login_do_before_user_login( $user_data ) {
 	// record last login
 	wasmo_user_lastlogin( $user_data->user_login, $user_data );
 	// send welcome?

--- a/includes/functions-saints.php
+++ b/includes/functions-saints.php
@@ -344,7 +344,7 @@ function wasmo_get_apostle_seniority_list( $include_deceased = false ) {
  */
 function wasmo_get_saint_seniority( $saint_id, $include_deceased = false ) {
 	$seniority_list = wasmo_get_apostle_seniority_list( $include_deceased );
-	$position       = array_search( $saint_id, $seniority_list ); // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+	$position       = array_search( $saint_id, $seniority_list, true );
 
 	if ( false === $position ) {
 		return null;
@@ -728,7 +728,7 @@ function wasmo_get_saint_related_posts( $saint_id, $limit = 10 ) {
 	);
 
 	foreach ( $relationship_posts as $post ) {
-		if ( ! in_array( $post->ID, $post_ids ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+		if ( ! in_array( $post->ID, $post_ids, true ) ) {
 			$post_ids[]      = $post->ID;
 			$related_posts[] = $post;
 		}
@@ -800,7 +800,7 @@ function wasmo_get_saint_related_media( $saint_id, $limit = 20 ) {
 	);
 
 	foreach ( $relationship_media as $media ) {
-		if ( ! in_array( $media->ID, $media_ids ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+		if ( ! in_array( $media->ID, $media_ids, true ) ) {
 			$media_ids[]     = $media->ID;
 			$related_media[] = $media;
 		}
@@ -918,7 +918,7 @@ function wasmo_get_saints_chart_data() {
 			'president_years'       => $president_years,
 			'roles'                 => $roles,
 			'is_first_presidency'   => $is_first_presidency,
-			'is_president'          => in_array( 'president', $roles ), // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+			'is_president'          => in_array( 'president', $roles, true ),
 			'served_under'          => wasmo_get_served_with_presidents( $apostle_id ),
 			'thumbnail'             => $thumbnail_url,
 		);
@@ -2631,7 +2631,7 @@ function wasmo_get_age_at_date( $saint_id, $date ) {
  * @param string $date      Date to calculate at (Y-m-d).
  * @return int|null Age difference (saint1 - saint2), or null if dates not available.
  */
-function wasmo_get_age_difference( $saint1_id, $saint2_id, $date = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+function wasmo_get_age_difference( $saint1_id, $saint2_id ) {
 	$birth1 = get_field( 'birthdate', $saint1_id );
 	$birth2 = get_field( 'birthdate', $saint2_id );
 

--- a/includes/functions-saints.php
+++ b/includes/functions-saints.php
@@ -2626,9 +2626,8 @@ function wasmo_get_age_at_date( $saint_id, $date ) {
 /**
  * Get age difference between two saints at a specific date
  *
- * @param int    $saint1_id First saint post ID.
- * @param int    $saint2_id Second saint post ID.
- * @param string $date      Date to calculate at (Y-m-d).
+ * @param int $saint1_id First saint post ID.
+ * @param int $saint2_id Second saint post ID.
  * @return int|null Age difference (saint1 - saint2), or null if dates not available.
  */
 function wasmo_get_age_difference( $saint1_id, $saint2_id ) {

--- a/includes/functions-template-tags.php
+++ b/includes/functions-template-tags.php
@@ -481,7 +481,7 @@ function wasmo_get_random_profile_url() {
  * @return WP_User_Query The modified user query object.
  */
 function wasmo_random_user_query( $class ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound
-	if ( 'rand' == $class->query_vars['orderby'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+	if ( 'rand' === $class->query_vars['orderby'] ) {
 		$class->query_orderby = str_replace(
 			'user_login',
 			'RAND()',

--- a/includes/functions-theme.php
+++ b/includes/functions-theme.php
@@ -42,7 +42,7 @@ function wasmo_add_google_fonts() {
 		'wasmo-google-fonts',
 		'https://fonts.googleapis.com/css?family=Josefin+Sans:ital,wght@0,100..700;1,100..700|Crimson+Text:400,700|Open+Sans:400,700&display=swap',
 		array(),
-		null
+		wp_get_theme()->get( 'Version' )
 	);
 }
 add_action( 'wp_enqueue_scripts', 'wasmo_add_google_fonts' );

--- a/includes/functions-theme.php
+++ b/includes/functions-theme.php
@@ -7,9 +7,11 @@ function wasmo_enqueue() {
 
 	$parent_style = 'parent-style'; // This is 'twentynineteen-style' for the Twenty Nineteen theme.
 
-	wp_enqueue_style( // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+	wp_enqueue_style(
 		$parent_style,
 		get_stylesheet_directory_uri() . '/twentynineteen.css',
+		array(),
+		wp_get_theme()->get( 'Version' )
 	);
 	wp_enqueue_style(
 		'wasmo-style',
@@ -36,10 +38,11 @@ add_action( 'wp_enqueue_scripts', 'wasmo_enqueue' );
  * https://fonts.google.com/specimen/Josefin+Sans
  */
 function wasmo_add_google_fonts() {
-	wp_enqueue_style( // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+	wp_enqueue_style(
 		'wasmo-google-fonts',
 		'https://fonts.googleapis.com/css?family=Josefin+Sans:ital,wght@0,100..700;1,100..700|Crimson+Text:400,700|Open+Sans:400,700&display=swap',
-		false
+		array(),
+		null
 	);
 }
 add_action( 'wp_enqueue_scripts', 'wasmo_add_google_fonts' );
@@ -64,7 +67,7 @@ add_action( 'after_setup_theme', 'wasmo_setup' );
  * @return string The modified menu items.
  */
 function wasmo_loginout_menu_link( $items, $args ) {
-	if ( $args->theme_location == 'utility' ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+	if ( $args->theme_location === 'utility' ) {
 		$userid = get_current_user_id();
 
 		$login  = '<li class="login"><a href="' . home_url( '/login/' ) . '" class="register">' . wasmo_get_icon_svg( 'join', 24 ) . __( ' Join', 'wasmo' ) . '</a></li>';

--- a/includes/media-auto-tag.php
+++ b/includes/media-auto-tag.php
@@ -133,7 +133,7 @@ function wasmo_get_media_for_tagging( $limit = 50, $offset = 0, $filter = 'all' 
 		$new_tags        = array_filter(
 			$potential_tags,
 			function ( $tag ) use ( $current_tag_ids ) {
-				return ! in_array( $tag->term_id, $current_tag_ids ); // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+				return ! in_array( $tag->term_id, $current_tag_ids, true );
 			}
 		);
 
@@ -309,7 +309,7 @@ function wasmo_apply_auto_tags( $media_ids = array(), $dry_run = false ) {
 				$new_tags        = array_filter(
 					$potential_tags,
 					function ( $tag ) use ( $current_tag_ids ) {
-						return ! in_array( $tag->term_id, $current_tag_ids ); // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+						return ! in_array( $tag->term_id, $current_tag_ids, true );
 					}
 				);
 

--- a/includes/saints-api.php
+++ b/includes/saints-api.php
@@ -189,7 +189,7 @@ add_action( 'rest_api_init', 'wasmo_register_fs_api_routes' );
  * Permission check for API endpoints
  * Requires authenticated user with manage_options capability
  */
-function wasmo_api_permission_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+function wasmo_api_permission_check() {
 	// Check if user is authenticated (Application Passwords work with this)
 	if ( ! is_user_logged_in() ) {
 		return new WP_Error(
@@ -1063,7 +1063,7 @@ function wasmo_format_saint_for_api( $saint_id, $include_marriages = false ) {
 /**
  * GET /saints/duplicates - Find saints with duplicate FamilySearch IDs
  */
-function wasmo_api_get_duplicate_saints( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+function wasmo_api_get_duplicate_saints() {
 	global $wpdb;
 
 	// Find FamilySearch IDs that appear more than once
@@ -1201,7 +1201,7 @@ function wasmo_api_merge_saint( $request ) {
 		foreach ( $marriages as $idx => $marriage ) {
 			// Check spouse relationship
 			$spouse_id = is_array( $marriage['spouse'] ) ? ( $marriage['spouse'][0] ?? null ) : $marriage['spouse'];
-			if ( $spouse_id == $source_id ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+			if ( $spouse_id === $source_id ) {
 				$marriages[ $idx ]['spouse'] = array( $target_id );
 				$updated                     = true;
 				++$updates['relationships_updated'];
@@ -1211,7 +1211,7 @@ function wasmo_api_merge_saint( $request ) {
 			if ( ! empty( $marriage['children'] ) ) {
 				foreach ( $marriage['children'] as $child_idx => $child ) {
 					$child_link = is_array( $child['child_link'] ) ? ( $child['child_link'][0] ?? null ) : $child['child_link'];
-					if ( $child_link == $source_id ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+					if ( $child_link === $source_id ) {
 						$marriages[ $idx ]['children'][ $child_idx ]['child_link'] = array( $target_id );
 						$updated = true;
 						++$updates['relationships_updated'];

--- a/includes/saints-associations.php
+++ b/includes/saints-associations.php
@@ -485,7 +485,7 @@ function wasmo_search_media_for_leader( $leader ) {
 		$results = $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		foreach ( $results as $row ) {
-			if ( ! in_array( $row->ID, $found_ids ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+			if ( ! in_array( $row->ID, $found_ids, true ) ) {
 				$found_ids[]     = $row->ID;
 				$match_locations = array();
 
@@ -522,14 +522,14 @@ function wasmo_search_media_for_leader( $leader ) {
 		$alt_results = $wpdb->get_results( $alt_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		foreach ( $alt_results as $row ) {
-			if ( ! in_array( $row->ID, $found_ids ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+			if ( ! in_array( $row->ID, $found_ids, true ) ) {
 				$found_ids[]         = $row->ID;
 				$matches[ $row->ID ] = array(
 					'id'         => $row->ID,
 					'match_term' => $search_term,
 					'match_in'   => array( 'alt_text' ),
 				);
-			} elseif ( isset( $matches[ $row->ID ] ) && ! in_array( 'alt_text', $matches[ $row->ID ]['match_in'] ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+			} elseif ( isset( $matches[ $row->ID ] ) && ! in_array( 'alt_text', $matches[ $row->ID ]['match_in'], true ) ) {
 				$matches[ $row->ID ]['match_in'][] = 'alt_text';
 			}
 		}
@@ -549,14 +549,14 @@ function wasmo_search_media_for_leader( $leader ) {
 		$file_results = $wpdb->get_results( $file_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		foreach ( $file_results as $row ) {
-			if ( ! in_array( $row->ID, $found_ids ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+			if ( ! in_array( $row->ID, $found_ids, true ) ) {
 				$found_ids[]         = $row->ID;
 				$matches[ $row->ID ] = array(
 					'id'         => $row->ID,
 					'match_term' => $search_term,
 					'match_in'   => array( 'filename' ),
 				);
-			} elseif ( isset( $matches[ $row->ID ] ) && ! in_array( 'filename', $matches[ $row->ID ]['match_in'] ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+			} elseif ( isset( $matches[ $row->ID ] ) && ! in_array( 'filename', $matches[ $row->ID ]['match_in'], true ) ) {
 				$matches[ $row->ID ]['match_in'][] = 'filename';
 			}
 		}
@@ -637,7 +637,7 @@ function wasmo_preview_leader_associations( $include_text_search = true ) {
 
 				$new_matches = array();
 				foreach ( $text_matches as $media_id => $match_info ) {
-					if ( ! in_array( $media_id, $existing_media ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+					if ( ! in_array( $media_id, $existing_media, true ) ) {
 						$new_matches[ $media_id ] = $match_info;
 					}
 				}
@@ -778,7 +778,7 @@ function wasmo_add_leader_to_content( $content_id, $leader_id ) {
 	}
 
 	// Check if already associated
-	if ( in_array( $leader_id, $existing ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+	if ( in_array( $leader_id, $existing, true ) ) {
 		return false;
 	}
 

--- a/includes/saints-duplicates.php
+++ b/includes/saints-duplicates.php
@@ -71,13 +71,13 @@ function wasmo_render_duplicates_page() {
 		'name_dates' => array_filter(
 			$duplicates,
 			function ( $dup ) {
-				return in_array( $dup['match_type'], array( 'name_birthdate', 'name_deathdate', 'name_birthdate_deathdate' ) ); // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+				return in_array( $dup['match_type'], array( 'name_birthdate', 'name_deathdate', 'name_birthdate_deathdate' ), true );
 			}
 		),
 		'wives'      => array_filter(
 			$duplicates,
 			function ( $dup ) {
-				return in_array( $dup['match_type'], array( 'wife_same_husband', 'wife_different_husbands' ) ); // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+				return in_array( $dup['match_type'], array( 'wife_same_husband', 'wife_different_husbands' ), true );
 			}
 		),
 		'extraneous' => array_filter(
@@ -1475,7 +1475,7 @@ function wasmo_merge_duplicate_saints_by_id( $primary_id, $merge_from_id ) {
 		foreach ( $marriages as $idx => $marriage ) {
 			// Update spouse relationships
 			$spouse_id = is_array( $marriage['spouse'] ) ? ( $marriage['spouse'][0] ?? null ) : $marriage['spouse'];
-			if ( $spouse_id == $merge_from_id ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+			if ( $spouse_id === $merge_from_id ) {
 				$marriages[ $idx ]['spouse'] = array( $primary_id );
 				$updated                     = true;
 				++$updates['relationships_updated'];
@@ -1485,7 +1485,7 @@ function wasmo_merge_duplicate_saints_by_id( $primary_id, $merge_from_id ) {
 			if ( ! empty( $marriage['children'] ) ) {
 				foreach ( $marriage['children'] as $child_idx => $child ) {
 					$child_link = is_array( $child['child_link'] ) ? ( $child['child_link'][0] ?? null ) : $child['child_link'];
-					if ( $child_link == $merge_from_id ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+					if ( $child_link === $merge_from_id ) {
 						$marriages[ $idx ]['children'][ $child_idx ]['child_link'] = array( $primary_id );
 						$updated = true;
 						++$updates['relationships_updated'];
@@ -1648,7 +1648,7 @@ function wasmo_merge_marriages( $target_id, $source_id, &$updates ) {
 			$target_spouse_fs_id = $target_marriage['spouse_familysearch_id'] ?? '';
 
 			// Match by spouse ID or FS ID
-			if ( ( $source_spouse_id && $source_spouse_id == $target_spouse_id ) || // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+			if ( ( $source_spouse_id && $source_spouse_id === $target_spouse_id ) ||
 				( $source_spouse_fs_id && $source_spouse_fs_id === $target_spouse_fs_id ) ) {
 				// Merge children
 				$target_children = $target_marriage['children'] ?: array();

--- a/includes/saints-images.php
+++ b/includes/saints-images.php
@@ -866,7 +866,7 @@ function wasmo_download_and_attach_image( $image_url, $leader_id ) {
 
 	// Clean up temp file
 	if ( file_exists( $tmp ) ) {
-		@unlink( $tmp ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+		wp_delete_file( $tmp );
 	}
 
 	if ( is_wp_error( $attachment_id ) ) {
@@ -1073,7 +1073,7 @@ function wasmo_bulk_import_images( $source = WASMO_IMAGE_SOURCE_AUTO ) {
 
 			if ( $error_code === 'has_image' ) {
 				++$results['skipped'];
-			} elseif ( in_array( $error_code, array( 'no_results', 'no_image', 'no_suitable_image', 'no_images', 'no_image_found' ) ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+			} elseif ( in_array( $error_code, array( 'no_results', 'no_image', 'no_suitable_image', 'no_images', 'no_image_found' ), true ) ) {
 				++$results['not_found'];
 				$results['errors'][] = $leader->post_title . ': ' . $result->get_error_message();
 			} else {

--- a/includes/saints-import.php
+++ b/includes/saints-import.php
@@ -2325,8 +2325,7 @@ function wasmo_import_wives_csv( $csv_path, $leader_name ) {
 /**
  * Create or update a wife saint record
  *
- * @param array  $data Wife data from CSV.
- * @param string $husband_name For context.
+ * @param array $data Wife data from CSV.
  * @return array|WP_Error Array with 'id' and 'created' flag, or error.
  */
 function wasmo_create_or_update_wife( $data ) {

--- a/includes/saints-import.php
+++ b/includes/saints-import.php
@@ -1586,7 +1586,10 @@ function wasmo_import_single_leader_full( $data, $update_existing = false, $impo
 			$image_result = wasmo_import_leader_featured_image( $post_id, $data['featured_image_url'], $data['name'] );
 			if ( is_wp_error( $image_result ) ) {
 				// Log error but don't fail the whole import
-				error_log( 'Failed to import image for ' . $data['name'] . ': ' . $image_result->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( 'Failed to import image for ' . $data['name'] . ': ' . $image_result->get_error_message() );
+				}
 			}
 		}
 	}
@@ -1828,7 +1831,7 @@ function wasmo_import_leader_featured_image( $post_id, $image_url, $leader_name 
 
 	// Clean up temp file
 	if ( file_exists( $tmp ) ) {
-		@unlink( $tmp ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+		wp_delete_file( $tmp );
 	}
 
 	if ( is_wp_error( $attachment_id ) ) {
@@ -2326,7 +2329,7 @@ function wasmo_import_wives_csv( $csv_path, $leader_name ) {
  * @param string $husband_name For context.
  * @return array|WP_Error Array with 'id' and 'created' flag, or error.
  */
-function wasmo_create_or_update_wife( $data, $husband_name ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+function wasmo_create_or_update_wife( $data ) {
 	$wife_name = trim( $data['wife_name'] ?? '' );
 
 	if ( empty( $wife_name ) ) {

--- a/includes/saints-settings.php
+++ b/includes/saints-settings.php
@@ -36,7 +36,7 @@ add_action( 'admin_init', 'wasmo_register_leader_settings' );
  * Clear First Presidency transient when settings are saved
  */
 function wasmo_clear_fp_transient_on_save( $old_value, $value, $option ) {
-	if ( in_array( $option, array( 'wasmo_current_president', 'wasmo_current_first_counselor', 'wasmo_current_second_counselor' ) ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+	if ( in_array( $option, array( 'wasmo_current_president', 'wasmo_current_first_counselor', 'wasmo_current_second_counselor' ), true ) ) {
 		delete_transient( 'wasmo_first_presidency' );
 	}
 }

--- a/includes/spotlight-posts-admin-page.php
+++ b/includes/spotlight-posts-admin-page.php
@@ -243,7 +243,7 @@ class Wasmo_Spotlight_Post_List_Table extends WP_List_Table {
 				return $item[ $column_name ];
 
 			default:
-				return print_r( $item, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				return wp_json_encode( $item );
 		}
 	}
 

--- a/template-parts/content/content-directory.php
+++ b/template-parts/content/content-directory.php
@@ -168,7 +168,7 @@ if ( false === $the_directory ) {
 	$total_users    = count( $filtered_users );
 	$counter        = 0;
 	$the_directory .= '<section class="entry-content the-directory directory-' . $context . ' directory-' . $state . ' directory-' . $max_profiles . '">';
-	$the_directory .= '<div class="directory directory-' . $context . ' ' . ( $lazy == true ? 'is-lazy' : 'not-lazy' ) . '" data-offset="' . $offset . '" data-total="' . $total_users . '" data-lazy="' . $lazy . '" data-lazy="' . $lazy . '">'; // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+	$the_directory .= '<div class="directory directory-' . $context . ' ' . ( $lazy === true ? 'is-lazy' : 'not-lazy' ) . '" data-offset="' . $offset . '" data-total="' . $total_users . '" data-lazy="' . $lazy . '" data-lazy="' . $lazy . '">';
 
 
 	foreach ( $filtered_users as $user ) {

--- a/template-polygamy.php
+++ b/template-polygamy.php
@@ -362,7 +362,7 @@ foreach ( $young_brides as $bride ) {
 					<?php
 					foreach ( $polygamists as $p ) :
 						$wives_pct = ( $p['num_wives'] / $max_wives ) * 100;
-						$bar_class = in_array( 'president', $p['role_slugs'] ?? array() ) ? 'bar-prophet' : 'bar-historical'; // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+						$bar_class = in_array( 'president', $p['role_slugs'] ?? array(), true ) ? 'bar-prophet' : 'bar-historical';
 						if ( $p['num_teenage_brides'] > 0 ) {
 							$bar_class .= ' has-teenage';
 						}


### PR DESCRIPTION
## Summary

Follows up on PR #69 by replacing `phpcs:ignore` inline suppressions with proper code fixes across 21 files. Addresses all of the low-risk, mechanical rules from issue #70.

### What was fixed

**`WordPress.PHP.StrictInArray.MissingTrueStrict`** (~20 occurrences)
- Added `true` as the third argument to every `in_array()` call
- Added `true` (strict) to `array_search()` in `functions-saints.php`

**`Universal.Operators.StrictComparisons.LooseEqual` / `LooseNotEqual`** (~21 occurrences)
- Replaced `==` with `===` and `!=` with `!==` throughout
- Includes the null comparisons in `wasmo_fix_post_counts()` (safe: `$type['status']` is set from a literal array)

**`WordPress.WP.EnqueuedResourceParameters.MissingVersion`** (2 occurrences in `functions-theme.php`)
- `twentynineteen.css`: added `array(), wp_get_theme()->get( 'Version' )`
- Google Fonts: changed deps from `false` to `array()`, added `null` version (no cache-busting query string for external CDN)

**`Generic.CodeAnalysis.UnusedFunctionParameter`** (~9 occurrences)
- Removed unused trailing parameters from hook/filter callbacks — PHP allows callers to pass more args than a function declares, so dropping the last unused param from the signature is safe
- Affected: `functions-acf.php`, `functions-email.php`, `functions-saints.php`, `saints-api.php`, `saints-import.php`

**`WordPress.PHP.NoSilencedErrors.Discouraged` + `WordPress.WP.AlternativeFunctions.unlink_unlink`** (3 occurrences)
- Replaced `@unlink( $tmp )` with `wp_delete_file( $tmp )` in `fs-verify.php`, `saints-images.php`, and `saints-import.php`

**`WordPress.PHP.DevelopmentFunctions.error_log_print_r`** (4 occurrences)
- Replaced `print_r( $item, true )` with `wp_json_encode( $item )` in the `column_default()` fallback of all four admin list-table classes

**`WordPress.PHP.DevelopmentFunctions.error_log_error_log`** (1 occurrence)
- Gated the `error_log()` call in `saints-import.php` behind `defined( 'WP_DEBUG' ) && WP_DEBUG`; the `phpcs:ignore` is retained because PHPCS flags the call regardless of runtime conditions

### What was intentionally left for separate issues

- `WordPress.Security.NonceVerification.Recommended` — requires per-handler review of GET-based form flows
- `WordPress.Security.ValidatedSanitizedInput.*` — requires context-by-context sanitization decisions
- `WordPress.DB.PreparedSQL.*` / `UnfinishedPrepare` — requires SQL review
- `WordPress.WP.AlternativeFunctions.file_system_operations_fopen/fclose` / `file_get_contents` — requires WP_Filesystem refactor

---
_Generated by [Claude Code](https://claude.ai/code/session_014eMkQNZBvMNpDtVETQS8ed)_