### PR TITLE
Release prep: 2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wasmo-theme",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wasmo-theme",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@wordpress/block-editor": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wasmo-theme",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "description": "wasmormon.org WordPress Theme",
     "main": "index.js",
     "scripts": {

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:           Evan Mullins
  Author URI:       https://circlecube.com
  Template:         twentynineteen
- Version:          2.7.0
+ Version:          2.7.1
  Tested up to:     7.0
  License:          GNU General Public License v2 or later
  License URI:      http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Release prep (2.7.1)

- Bumped **package.json** / **package-lock.json** with `npm version patch`
- Synced **style.css** (`Version:`) from package.json
- Ran `npm run build` to verify compile

### Merged PRs since last tag

- #74 chore(lint): replace phpcs:ignore suppressions with real fixes (#70)
- #73 npm: bump @wordpress/env from 10.39.0 to 11.12.0
- #72 Composer Dev(deps-dev): bump yoast/phpunit-polyfills from 2.0.5 to 4.0.0
- #71 GitHub Actions(deps): bump actions/upload-artifact from 4 to 7
- #69 feat: lint, wpunit, e2e, coverage, audit — CI parity with bandiverse (closes #66)
- #68 fix(prep-release): fail fast when RELEASE_PAT secret is missing
- #67 chore(release): prepare 2.6.4 -> 2.7.0
- #65 chore: fix updater metadata + add version scripts (prep for workflow suite)
- #64 Fix restore button: always keep box HTML in DOM, hide with inline style

_Workflow: `.github/workflows/prep-release.yml`_
