### PR TITLE
Release prep: 2.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wasmo-theme",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wasmo-theme",
-            "version": "2.7.2",
+            "version": "2.7.3",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@wordpress/block-editor": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wasmo-theme",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "wasmormon.org WordPress Theme",
     "main": "index.js",
     "scripts": {

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:           Evan Mullins
  Author URI:       https://circlecube.com
  Template:         twentynineteen
- Version:          2.7.2
+ Version:          2.7.3
  Tested up to:     7.0
  License:          GNU General Public License v2 or later
  License URI:      http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Release prep (2.7.3)

- Bumped **package.json** / **package-lock.json** with `npm version patch`
- Synced **style.css** (`Version:`) from package.json
- Ran `npm run build` to verify compile

### Merged PRs since last tag

- #80 Update/video profiles again
- #79 Release prep: 2.7.2
- #78 Update video profiles
- #77 GitHub Actions(deps): bump dorny/paths-filter from 3 to 4
- #76 chore(deps-dev): bump squizlabs/php_codesniffer from 3.13.5 to 3.13.6
- #75 Release prep: 2.7.1

_Workflow: `.github/workflows/prep-release.yml`_
