### PR TITLE
fix(updates): strip 'v' prefix from GitHub tag so theme updates are detected

### DIFF
--- a/includes/updates.php
+++ b/includes/updates.php
@@ -22,3 +22,41 @@ $wasmoThemeUpdater->setDataOverrides(
 		'tested'       => '6.2',
 	)
 );
+
+// GitHub release tags are prefixed with 'v' (e.g. v2.7.5). PHP's version_compare
+// treats the leading 'v' as a special string ranked below all numerics, so
+// version_compare('v2.7.5', '2.7.5', '>') returns false and updates are never
+// detected. This filter runs after WP_Forge (priority 10) to normalize versions
+// and re-classify any release that WP_Forge placed in no_update due to the prefix.
+add_filter(
+	'site_transient_update_themes',
+	function ( $transient ) {
+		if ( empty( $transient ) || ! is_object( $transient ) ) {
+			return $transient;
+		}
+
+		$stylesheet        = 'wasmo-theme';
+		$installed_version = wp_get_theme( $stylesheet )->get( 'Version' );
+
+		foreach ( array( 'response', 'no_update' ) as $bucket ) {
+			if ( ! empty( $transient->{$bucket}[ $stylesheet ] ) ) {
+				$version                                        = ltrim( $transient->{$bucket}[ $stylesheet ]['version'] ?? '', 'v' );
+				$transient->{$bucket}[ $stylesheet ]['version'] = $version;
+				$transient->{$bucket}[ $stylesheet ]['new_version'] = $version;
+			}
+		}
+
+		// WP_Forge may have placed the release in no_update because the v-prefixed
+		// version compared as older. Re-evaluate now that versions are normalized.
+		if ( ! empty( $transient->no_update[ $stylesheet ] ) ) {
+			$release = $transient->no_update[ $stylesheet ];
+			if ( version_compare( $release['version'], $installed_version, '>' ) ) {
+				$transient->response[ $stylesheet ] = $release;
+				unset( $transient->no_update[ $stylesheet ] );
+			}
+		}
+
+		return $transient;
+	},
+	20
+);


### PR DESCRIPTION
## Problem

Theme updates released as `v2.7.5` (GitHub's `tag_name`) were never surfaced in the WordPress admin even though a newer version existed. The installed theme version was `2.7.5` (no prefix).

Root cause: WP_Forge maps `tag_name` directly to the `version` field, so the stored version is `v2.7.5`. PHP's `version_compare` treats the leading `v` as a special string ranked below all numeric segments, making `version_compare('v2.7.5', '2.7.5', '>')` return `false`. WP_Forge therefore always places the release in `no_update` instead of `response`, and WordPress never prompts for an update.

## Fix

Add a `site_transient_update_themes` filter at priority 20 (after WP_Forge's priority-10 filter) in `includes/updates.php` that:

1. Strips the leading `v` from `version` and `new_version` for the `wasmo-theme` entry in both `response` and `no_update` buckets.
2. Re-evaluates any release that WP_Forge placed in `no_update` and moves it to `response` when the normalized version is actually greater than the installed version.

No changes to vendor code. No change to the data map — `tag_name` is still the source; we normalize after the fact.

---
_Generated by [Claude Code](https://claude.ai/code/session_011dsyQhQyh9yQuT64cVRFG1)_