### PR TITLE
Release prep: 2.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wasmo-theme",
-    "version": "2.7.5",
+    "version": "2.7.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wasmo-theme",
-            "version": "2.7.5",
+            "version": "2.7.6",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@wordpress/block-editor": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wasmo-theme",
-    "version": "2.7.5",
+    "version": "2.7.6",
     "description": "wasmormon.org WordPress Theme",
     "main": "index.js",
     "scripts": {

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:           Evan Mullins
  Author URI:       https://circlecube.com
  Template:         twentynineteen
- Version:          2.7.5
+ Version:          2.7.6
  Tested up to:     7.0
  License:          GNU General Public License v2 or later
  License URI:      http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Release prep (2.7.6)

- Bumped **package.json** / **package-lock.json** with `npm version patch`
- Synced **style.css** (`Version:`) from package.json
- Ran `npm run build` to verify compile

### Merged PRs since last tag

- #91 fix(updates): cache GitHub release to fix WP_Forge rate-limit exhaustion
- #90 fix(updates): strip 'v' prefix from GitHub tag so theme updates are detected
- #89 Release prep: 2.7.5
- #87 npm Dev(deps-dev): bump @wordpress/env from 11.12.0 to 11.13.0
- #86 npm(deps): bump @wordpress/components from 38.0.0 to 39.0.0
- #85 npm Dev(deps-dev): bump @wordpress/scripts from 34.0.0 to 34.1.0
- #84 npm(deps): bump @wordpress/i18n from 6.25.0 to 6.26.0

_Workflow: `.github/workflows/prep-release.yml`_
